### PR TITLE
Fix of get_model incorrect string splitting

### DIFF
--- a/musicnet/scripts/train.py
+++ b/musicnet/scripts/train.py
@@ -56,7 +56,7 @@ def schedule(epoch):
 def get_model(model, feature_dim):
     if model.startswith('complex'):
         complex_ = True
-        model = model.split('_')[1]
+        model = model[8:]
     else:
         complex_ = False
     if complex_:


### PR DESCRIPTION
Previous line 59 would split argument "complex_shallow_convnet" on underscores giving "complex", "shallow", "convnet", then selected the second giving "shallow" and would try to match this with "shallow_convnet" which could never be true.
This fix simply strips the leading "complex_" allowing correct comparison.